### PR TITLE
fix: Server startup

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -28,9 +28,8 @@ require('../socket/socket')(io)
  * Listen on provided port, on all network interfaces.
  */
 
-server.listen(port);
+server.listen(port, onListening);
 server.on('error', onError);
-server.on('listening', onListening);
 
 /**
  * Normalize a port into a number, string, or false.


### PR DESCRIPTION
Node's HTTP server does not have a `listening` event, but rather a callback parameter for it's `server.listen` function: https://nodejs.org/api/http.html#class-httpserver