### PR TITLE
fix: pressing Enter in URL box no longer 404s on /search

### DIFF
--- a/views/layout.hbs
+++ b/views/layout.hbs
@@ -64,12 +64,22 @@
    }
   })
   
-  // Download a website on click
-   const downloadBtn =  document.getElementById("download");
-   downloadBtn.onclick=()=>{
+  // Download a website on click (or when pressing Enter in the form)
+   function startDownload(){
         var website = document.getElementById('website').value
+        if(!website) return;
         console.log("Now downloading the website ... %s",website)
         socket.emit('request', { token: localStorage['token'] , website});
+   }
+   const downloadBtn =  document.getElementById("download");
+   downloadBtn.onclick = startDownload;
+   // Prevent the form's default GET /search submission (which 404s) and download instead
+   const downloadForm = document.querySelector('form.form');
+   if(downloadForm){
+     downloadForm.addEventListener('submit', function(e){
+       e.preventDefault();
+       startDownload();
+     });
    }
 
 


### PR DESCRIPTION
## Problem

Typing a URL and pressing **Enter** (instead of clicking the download button) submits the page form via `GET /search`. There is no `/search` route, so Express's catch-all returns a 404 and logs `NotFoundError: Not Found` from `app.js`. The download functionality was only wired to the button's `onclick` handler, so Enter — the most natural action — silently failed.

## Fix

Intercept the form's `submit` event in `views/layout.hbs`, call `preventDefault()` to stop the navigation to `/search`, and trigger the same socket-based download. The download logic is extracted into a shared `startDownload()` function used by both the button click and the form submit.

No new dependencies, no route or server changes — one template file touched.

## Testing

- Pressing **Enter** in the URL input now starts the download instead of navigating to `/search` (no more 404).
- Clicking the download button still works exactly as before.
- Verified the full pipeline end-to-end (socket → `wget` → `archiver`) against `http://example.com`, which produced a valid `public/sites/example.com.zip` containing the mirrored `index.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved download functionality to prevent errors when submitting forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->