### PR TITLE
docs: document wget prerequisite (fixes local "not working" issue)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,22 @@ Download the complete source code of any website (including all assets) 🔨.
 [![Deploy to Render](https://binbashbanana.github.io/deploy-buttons/buttons/remade/render.svg)](https://render.com/deploy?repo=https://github.com/AhmadIbrahiim/Website-downloader)
 
 
+## Prerequisites ⚙️
+
+This app is a wrapper around the [`wget`](https://www.gnu.org/software/wget/) command-line
+tool — it shells out to `wget` to download website assets. **`wget` must be installed and
+available on your `PATH`, otherwise downloads silently produce empty `.zip` files.**
+
+- **Linux (Debian/Ubuntu):** `sudo apt-get install wget` (usually preinstalled)
+- **macOS:** `brew install wget`
+- **Windows:** `winget install JernejSimoncic.Wget` (or `choco install wget`)
+
+> **Windows notes:**
+> - After installing, **restart your terminal** so the updated `PATH` is picked up.
+> - Verify the install with `wget.exe --version` — it should print `GNU Wget 1.21.4`.
+> - In PowerShell, bare `wget` is a built-in alias for `Invoke-WebRequest`, so use
+>   `wget.exe` when testing. The app itself invokes `wget` via `cmd.exe`, so it works fine.
+
 ## How to run it 🤔
 
 - `git clone https://github.com/AhmadIbrahiim/Website-downloader.git`


### PR DESCRIPTION
## Summary

Fixes the "**Not Working When Run Locally**" problem reported in #102.

The app is a thin wrapper around the [`wget`](https://www.gnu.org/software/wget/) CLI — it shells out to `wget` to download website assets. When `wget` is not installed (common on Windows, and not guaranteed on fresh machines), the download step silently fails and the archiver zips an empty folder, producing a **~22-byte empty `.zip`**. Nothing tells the user why.

This PR documents `wget` as a required prerequisite so users can get it running locally.

## Changes

- Add a **Prerequisites** section to the README:
  - Explains that `wget` must be installed and on `PATH`.
  - Install commands for Linux (`apt-get`), macOS (`brew`), and Windows (`winget` / `choco`).
  - Windows-specific notes: restart the terminal after install so `PATH` refreshes, verify with `wget.exe --version`, and a heads-up that bare `wget` in PowerShell is an alias for `Invoke-WebRequest` (the app invokes `wget` via `cmd.exe`, so it works regardless).

## Testing

- Installed `wget` on Windows via `winget install JernejSimoncic.Wget`.
- Ran the app and downloaded `http://example.com` end-to-end through the socket flow — produced a valid non-empty zip (505 bytes) instead of the previous empty 22-byte zip.

Docs-only change; no runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a prerequisites section explaining the required `wget` installation.
  - Included installation guidance for Linux, macOS, and Windows.
  - Added Windows-specific instructions for restarting the terminal and verifying the installation.
  - Warned that missing `wget` may result in empty ZIP files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->