### PR TITLE
Fix downloads silently reporting success when nothing was archived

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,9 @@ build/Release
 # Dependency directory
 # https://docs.npmjs.com/misc/faq#should-i-check-my-node-modules-folder-into-git
 node_modules
+
+# Working directory for in-progress downloads
+downloads
+
+# Archives generated for users
+public/sites/*.zip

--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ Download the complete source code of any website (including all assets) 🔨.
 [![Deploy to Render](https://binbashbanana.github.io/deploy-buttons/buttons/remade/render.svg)](https://render.com/deploy?repo=https://github.com/AhmadIbrahiim/Website-downloader)
 
 
+## Requirements 📦
+
+- Node.js 16 or newer
+- `wget` on the `PATH`. The app shells out to it, and nothing will download without it:
+  - Debian/Ubuntu: `apt install wget`
+  - macOS: `brew install wget`
+  - Windows: `winget install JernejSimoncic.Wget`
+
 ## How to run it 🤔
 
 - `git clone https://github.com/AhmadIbrahiim/Website-downloader.git`
@@ -41,6 +49,14 @@ Download the complete source code of any website (including all assets) 🔨.
 - `$ npm install`
 - `$ npm start`
 - `http://localhost:3000/`
+
+### Optional settings
+
+| Variable | Default | What it does |
+| --- | --- | --- |
+| `PORT` | `3000` | Port the server listens on |
+| `DOWNLOAD_QUOTA` | `100m` | Size ceiling passed to wget, so one request cannot fill the disk |
+| `DOWNLOAD_TIMEOUT_MS` | `300000` | How long a single download may run before it is stopped |
 
 
 

--- a/archiver/index.js
+++ b/archiver/index.js
@@ -1,55 +1,69 @@
 var archiver = require('archiver');
 var fs = require('fs');
+var path = require('path');
 
+var SITES_DIR = path.join(__dirname, '..', 'public', 'sites');
 
-module.exports= (file,io,data)=>{
+/**
+ * Zips sourceDir into public/sites/<zipName>.zip and reports the outcome
+ * through the callback.
+ *
+ * Every failure here used to be thrown from inside an event handler, which
+ * took the whole server down for every connected user. Failures are now passed
+ * back to the caller so a single bad download only affects that one request.
+ */
+module.exports = (sourceDir, zipName, callback) => {
+  var settled = false;
+  var finish = (err) => {
+    if (settled) return;
+    settled = true;
+    callback(err, zipName);
+  };
 
-    var output = fs.createWriteStream("./public/sites/" +file+ '.zip');
-var archive = archiver('zip', {
-  zlib: { level: 9 } // Sets the compression level.
-});
- 
-// listen for all archive data to be written
-// 'close' event is fired only when a file descriptor is involved
-output.on('close', function() {
-  console.log(archive.pointer() + ' total bytes');
-  console.log('archiver has been finalized and the output file descriptor has closed.');
-  io.emit(data.token,{progress:"Completed",file})
-
-});
- 
-// This event is fired when the data source is drained no matter what was the data source.
-// It is not part of this library but rather from the NodeJS Stream API.
-// @see: https://nodejs.org/api/stream.html#stream_event_end
-output.on('end', function() {
-  console.log('Data has been drained');
-});
- 
-// good practice to catch warnings (ie stat failures and other non-blocking errors)
-archive.on('warning', function(err) {
-  if (err.code === 'ENOENT') {
-    // log warning
-  } else {
-    // throw error
-    throw err;
+  try {
+    fs.mkdirSync(SITES_DIR, { recursive: true });
+  } catch (err) {
+    finish(err);
+    return null;
   }
-});
- 
-// good practice to catch this error explicitly
-archive.on('error', function(err) {
-  throw err;
-});
- 
-// pipe archive data to the file
-archive.pipe(output);
 
-// append files from a sub-directory and naming it `new-subdir` within the archive
+  var zipPath = path.join(SITES_DIR, zipName + '.zip');
+  var output = fs.createWriteStream(zipPath);
+  var archive = archiver('zip', {
+    zlib: { level: 9 } // Sets the compression level.
+  });
 
-archive.directory('./'+file,false);
+  // listen for all archive data to be written
+  // 'close' event is fired only when a file descriptor is involved
+  output.on('close', function () {
+    console.log(archive.pointer() + ' total bytes written to ' + zipPath);
+    finish(null);
+  });
 
-// finalize the archive (ie we are done appending files but streams have to finish yet)
-// 'close', 'end' or 'finish' may be fired right after calling this method so register to them beforehand
-archive.finalize();
+  // Without this the stream throws on its own, and an unhandled stream error
+  // ends the process. A missing public/sites directory was enough to do it.
+  output.on('error', function (err) {
+    finish(err);
+  });
 
- 
-}
+  // good practice to catch warnings (ie stat failures and other non-blocking errors)
+  archive.on('warning', function (err) {
+    console.warn('archive warning: ' + err.message);
+  });
+
+  archive.on('error', function (err) {
+    finish(err);
+  });
+
+  // pipe archive data to the file
+  archive.pipe(output);
+
+  // append the downloaded site, without wrapping it in an extra folder
+  archive.directory(sourceDir, false);
+
+  // finalize the archive (ie we are done appending files but streams have to finish yet)
+  // 'close', 'end' or 'finish' may be fired right after calling this method so register to them beforehand
+  archive.finalize();
+
+  return archive;
+};

--- a/socket/socket.js
+++ b/socket/socket.js
@@ -1,23 +1,29 @@
 var wget = require('../wget');
-var archiver = require('../archiver');
 
 module.exports = (io) => {
   io.on('connection', function (socket) {
     socket.on('request', function (data) {
-      console.log("Request connection received %s", data.token);
-      wget(io, data);
+      if (!data || typeof data.token !== 'string' || !data.token) return;
+
+      // The handle returned by wget() is now stored on the socket. It never was
+      // before, so the cleanup below could never find a process to stop.
+      if (socket.job) {
+        socket.emit(data.token, { error: 'A download is already running on this connection.' });
+        return;
+      }
+
+      console.log('Request connection received %s', data.token);
+      socket.job = wget(socket, data, function () {
+        socket.job = null;
+      });
     });
 
     socket.on('disconnect', function () {
-      console.log("User disconnected");
+      console.log('User disconnected');
       // Stop the wget process and remove partially downloaded files
-      if (socket.wgetProcess) {
-        socket.wgetProcess.kill();
-        // Add code to remove partially downloaded files
-      }
-      // Stop the archiving process if the user disconnects
-      if (socket.archiverProcess) {
-        socket.archiverProcess.abort();
+      if (socket.job) {
+        socket.job.cancel();
+        socket.job = null;
       }
     });
   });

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -12,7 +12,7 @@
   <div class="row">
     <div class="col-lg-12" style="float: none; margin: 0 auto;">
       <div id="custom-search-input">
-          <form method="get" class="form" action="/search">
+          <form class="form" id="downloadForm">
         <div class="input-group col-md-12">
                 <input type="text" class="form-control input-lg" id="website" placeholder="https://www.google.com" />
                 <span class="input-group-btn">

--- a/views/layout.hbs
+++ b/views/layout.hbs
@@ -28,49 +28,90 @@
 <script>
   var numberOfFiles = 0;
   const downloadWebsite = document.getElementsByClassName('btn-success')[0];
+  const downloadBtn = document.getElementById('download');
+  const websiteInput = document.getElementById('website');
+  const progressBar = document.getElementById('progress');
+  const filesLine = document.getElementById('nFilesP');
+  const filesCount = document.getElementById('nFiles');
+  // Looked up once. This used to be declared inside one branch of the handler
+  // while the other branches relied on the browser's implicit window global.
+  const log = document.getElementById('log');
+
   // connect to current socket.io server
   var socket = io.connect(document.URL);
   if(!localStorage['token'])
   localStorage['token']=generateToken(20);
-  
+
   // wait for events for this token
   socket.on(localStorage['token'],(event)=>{
   console.log(event)
-  document.getElementById('progress').hidden=false;
+
+  // The server now says so when a download fails, instead of reporting an
+  // empty archive as a finished download.
+  if(event.error)
+  {
+       progressBar.hidden=true;
+       log.textContent='';
+       const failure=document.createElement('strong');
+       failure.style.color='#c0392b';
+       failure.textContent=event.error;
+       log.appendChild(failure);
+       downloadBtn.disabled=false;
+       return;
+  }
+
+  progressBar.hidden=false;
   if(event.progress=="Converting")
   {
-    log.innerHTML=(`<h5>100%! Compressing your website...</h5><br>`)
+    log.textContent='100%! Compressing your website...'
 
   }
    else if(event.progress=="Completed")
    {
-        document.getElementById('progress').hidden=true;
-        log.innerHTML=(`<code>Compressing completed successfully !</code><br>`)
-        downloadWebsite.style='display:'
+        progressBar.hidden=true;
+        log.textContent='Compressing completed successfully !'
+        downloadWebsite.style.display=''
         downloadWebsite.onclick=function()
         {
          window.location='/sites/'+event.file+".zip";
         }
+        downloadBtn.disabled=false;
 
    }
    else
    {
-        const log = document.getElementById('log');
         if(event.progress.includes('200 OK'))
-        numberOfFiles++;
-        document.getElementById('nFilesP').hidden=false;
-        document.getElementById('nFiles').innerHTML=numberOfFiles
-        log.innerHTML=(`<code> ${event.progress}</code><br>`)
+        {
+            numberOfFiles++;
+        }
+        filesLine.hidden=false;
+        filesCount.textContent=numberOfFiles
+        // textContent, not innerHTML: this text comes from the site being
+        // downloaded and should never be parsed as markup.
+        log.textContent=event.progress
    }
   })
-  
+
   // Download a website on click
-   const downloadBtn =  document.getElementById("download");
-   downloadBtn.onclick=()=>{
-        var website = document.getElementById('website').value
+   function startDownload()
+   {
+        var website = websiteInput.value
+        if(!website.trim()) return;
         console.log("Now downloading the website ... %s",website)
+        numberOfFiles=0;
+        filesCount.textContent='0';
+        log.textContent='';
+        downloadWebsite.style.display='none';
+        downloadBtn.disabled=true;
         socket.emit('request', { token: localStorage['token'] , website});
    }
+   downloadBtn.onclick=startDownload;
+   // Pressing Enter used to submit the form to /search, which does not exist
+   // and returned a 404 page.
+   document.getElementById('downloadForm').addEventListener('submit',(e)=>{
+        e.preventDefault();
+        startDownload();
+   });
 
 
 

--- a/wget/index.js
+++ b/wget/index.js
@@ -1,14 +1,23 @@
-var util = require('util'),
-    exec = require('child_process').exec;
-    var archiver = require('../archiver')
-    var fs = require('fs');
-    var path = require('path');
+var execFile = require('child_process').execFile;
+var crypto = require('crypto');
+var fs = require('fs');
+var path = require('path');
+var archive = require('../archiver');
 
-module.exports=(io,data)=>{
-
-// download all website assets 
 /**
- * wget --mirror --convert-links --adjust-extension --page-requisites 
+ * Every download gets its own directory under downloads/, which keeps two
+ * people downloading the same site from writing into each other's files and
+ * keeps cleanup from ever reaching outside this folder.
+ */
+var DOWNLOAD_ROOT = path.join(__dirname, '..', 'downloads');
+
+// wget mirrors recursively, so without a ceiling a single request can fill the
+// disk. Both limits can be raised through the environment.
+var QUOTA = process.env.DOWNLOAD_QUOTA || '100m';
+var TIMEOUT_MS = Number(process.env.DOWNLOAD_TIMEOUT_MS) || 5 * 60 * 1000;
+
+/**
+ * wget --mirror --convert-links --adjust-extension --page-requisites
  * --no-parent http://example.org
  * --mirror – Makes (among other things) the download recursive.
  * --convert-links – convert all the links (also to stuff like CSS stylesheets) to relative, so it will be suitable for offline viewing.
@@ -16,61 +25,187 @@ module.exports=(io,data)=>{
  * --page-requisites – Download things like CSS style-sheets and images required to properly display the page offline.
  * --no-parent – When recurring do not ascend to the parent directory. It useful for restricting the download to only a portion of the site.
  */
-let website ="";
-const child = exec(`wget -mkEpnp --no-if-modified-since ${data.website}`);
+module.exports = (socket, data, onFinished) => {
+  var done = typeof onFinished === 'function' ? onFinished : function () {};
+  var send = (payload) => socket.emit(data.token, payload);
 
-// read stdout from the current child.
-child.stderr.on("data",(response)=>{
-    const responseText = response.toString();
+  var target = parseTarget(data.website);
+  if (!target) {
+    send({ error: 'That does not look like a website address. Try something like https://example.com' });
+    done();
+    return null;
+  }
 
-    if(!website)
-    {
-        const resolvingMatch = responseText.match(/Resolving\s+([^\s]+)\s+\(/);
-        if (resolvingMatch && resolvingMatch[1]) {
-            website = resolvingMatch[1];
-        }
+  var jobId = crypto.randomBytes(8).toString('hex');
+  var jobDir = path.join(DOWNLOAD_ROOT, jobId);
+  try {
+    fs.mkdirSync(jobDir, { recursive: true });
+  } catch (err) {
+    send({ error: 'Could not create a working directory on the server: ' + err.message });
+    done();
+    return null;
+  }
+
+  // execFile rather than exec: the address is passed as a separate argument and
+  // never reaches a shell, so it cannot be used to run other commands.
+  var child = execFile('wget', [
+    '-mkEpnp',
+    '--no-if-modified-since',
+    '--quota=' + QUOTA,
+    target.href
+  ], { cwd: jobDir, maxBuffer: 32 * 1024 * 1024 });
+
+  var settled = false;
+  var cancelled = false;
+  var timedOut = false;
+  var stderrTail = [];
+
+  var timer = setTimeout(() => {
+    timedOut = true;
+    child.kill();
+  }, TIMEOUT_MS);
+
+  var fail = (message) => {
+    if (settled) return;
+    settled = true;
+    clearTimeout(timer);
+    removeJobDir(jobDir);
+    send({ error: message });
+    done();
+  };
+
+  // Fires when wget itself cannot be started, which on a fresh machine almost
+  // always means it is not installed.
+  child.on('error', (err) => {
+    if (err.code === 'ENOENT') {
+      fail('wget is not installed on the server. Install it and restart the app: ' +
+           'apt install wget, brew install wget, or winget install JernejSimoncic.Wget');
+      return;
     }
-    io.emit(data.token,{progress:responseText})
-})
+    fail('Could not start the download: ' + err.message);
+  });
 
-child.stderr.on('close',(response)=>{
-    const websiteFolder = website || getWebsiteFolderName(data.website);
+  child.stderr.on('data', (chunk) => {
+    var text = chunk.toString();
+    stderrTail = stderrTail.concat(text.split('\n')).slice(-60);
+    send({ progress: text });
+  });
 
-    if (!websiteFolder) {
-        io.emit(data.token, { progress: "Unable to determine downloaded website folder." });
-        return;
+  child.on('close', (code) => {
+    if (settled) return;
+    clearTimeout(timer);
+
+    if (cancelled) {
+      settled = true;
+      removeJobDir(jobDir);
+      done();
+      return;
+    }
+    if (timedOut) {
+      fail('The download took longer than ' + Math.round(TIMEOUT_MS / 1000) +
+           ' seconds and was stopped. Try a smaller site or a specific page.');
+      return;
     }
 
-    io.emit(data.token,{progress:"Converting"})
-    archiver(websiteFolder,io,data)
-})
-
-// Handle process termination and cleanup
-child.on('exit', (code, signal) => {
-    if (signal === 'SIGTERM') {
-        console.log('Process terminated');
-        removePartiallyDownloadedFiles(website);
+    // Trust the filesystem rather than wget's output. wget writes nothing at
+    // all for an off-site redirect, a robots.txt exclusion or a 403, and the
+    // previous approach of naming the folder from the first "Resolving" line
+    // then archived a directory that was never created.
+    if (countFiles(jobDir) === 0) {
+      fail('Nothing could be downloaded from ' + target.hostname + '. ' +
+           explainFailure(stderrTail, code));
+      return;
     }
-});
 
-function removePartiallyDownloadedFiles(website) {
-    const directory = path.join(__dirname, '../', website);
-    fs.rmdir(directory, { recursive: true }, (err) => {
-        if (err) {
-            console.error(`Error while removing partially downloaded files: ${err.message}`);
-        } else {
-            console.log('Partially downloaded files removed successfully');
-        }
+    settled = true;
+    send({ progress: 'Converting' });
+
+    var zipName = target.hostname.replace(/[^a-zA-Z0-9._-]/g, '_') + '-' + jobId;
+    archive(jobDir, zipName, (err, name) => {
+      removeJobDir(jobDir);
+      if (err) {
+        send({ error: 'The site downloaded but could not be compressed: ' + err.message });
+      } else {
+        send({ progress: 'Completed', file: name });
+      }
+      done();
     });
+  });
+
+  return {
+    cancel: function () {
+      cancelled = true;
+      child.kill();
+    }
+  };
+};
+
+/**
+ * Accepts what the user typed and returns a URL only if it is a real http(s)
+ * address. Anything else is rejected before it reaches wget.
+ */
+function parseTarget(input) {
+  if (typeof input !== 'string' || !input.trim()) return null;
+  var raw = input.trim();
+  var url;
+  try {
+    // Only assume http:// when no scheme was given at all. Prefixing a value
+    // that already has one turns file:///etc/passwd into a request for a host
+    // called "file" instead of rejecting it.
+    url = new URL(/^[a-z][a-z0-9+.-]*:/i.test(raw) ? raw : 'http://' + raw);
+  } catch (err) {
+    return null;
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+  if (!url.hostname) return null;
+  return url;
 }
 
-function getWebsiteFolderName(websiteUrl) {
-    try {
-        const normalizedUrl = /^https?:\/\//i.test(websiteUrl) ? websiteUrl : `http://${websiteUrl}`;
-        const parsedUrl = new URL(normalizedUrl);
-        return parsedUrl.port ? `${parsedUrl.hostname}:${parsedUrl.port}` : parsedUrl.hostname;
-    } catch (error) {
-        return "";
-    }
+/**
+ * wget's closing lines are usually a summary, so the last line is rarely the
+ * reason anything failed. Prefer the last line that actually looks like one.
+ */
+function explainFailure(lines, exitCode) {
+  var interesting = /failed|unable|refused|denied|ERROR \d|error \d|robots|No such|not found|forbidden|timed out|giving up|Unsupported scheme/i;
+  for (var i = lines.length - 1; i >= 0; i--) {
+    var line = lines[i].trim();
+    if (line && interesting.test(line)) return line;
+  }
+  if (exitCode === 8) return 'The server refused the request (it may block automated downloads).';
+  return 'wget exited with code ' + exitCode + ' without saving any files.';
 }
+
+function countFiles(directory) {
+  var total = 0;
+  var entries;
+  try {
+    entries = fs.readdirSync(directory, { withFileTypes: true });
+  } catch (err) {
+    return 0;
+  }
+  for (var i = 0; i < entries.length; i++) {
+    if (entries[i].isDirectory()) {
+      total += countFiles(path.join(directory, entries[i].name));
+    } else {
+      total++;
+    }
+  }
+  return total;
+}
+
+/**
+ * Deletes a single job directory. The guard matters: the previous version
+ * joined an empty string onto the app root and recursively deleted the whole
+ * application whenever the hostname had not been captured yet.
+ */
+function removeJobDir(directory) {
+  var resolved = path.resolve(directory);
+  var root = path.resolve(DOWNLOAD_ROOT);
+  if (resolved === root || !resolved.startsWith(root + path.sep)) {
+    console.error('Refusing to delete a path outside the downloads folder: ' + resolved);
+    return;
+  }
+  fs.rm(resolved, { recursive: true, force: true }, (err) => {
+    if (err) console.error('Could not clean up ' + resolved + ': ' + err.message);
+  });
 }


### PR DESCRIPTION
## The problem

The download pipeline reports success regardless of what actually happened. If wget is missing, blocked by the target site, or simply saves nothing, the app still emits `Completed` and serves a 22-byte zip containing zero entries, while the page shows "Compressing completed successfully !" next to an enabled download button.

I reproduced it two ways:

- `http://bit.ly`, where wget writes no directory for an off-site redirect
- wget absent from `PATH`, so the child process fails immediately

Both produced an empty archive presented as a finished download. I think this is what sits behind #90, and possibly #75.

### Root cause

`wget/index.js` chose the folder to archive by scraping the first `Resolving <host>` line out of wget's stderr, then archived that path without checking it existed. wget writes no directory at all for an off-site redirect, a robots.txt exclusion or a 403, so the archiver was handed a path that had never been created and produced an empty zip.

### Other faults found while tracing it

- Archive and write-stream errors are thrown from inside event handlers, which ends the Node process for every connected user. A missing `public/sites` directory on its own was enough to trigger it.
- `removePartiallyDownloadedFiles()` builds its target with `path.join(__dirname, '../', website)`. When `website` is still `""`, which is the case whenever no `Resolving` line has been seen yet, that resolves to the application root, and the recursive delete removes the app itself. It also uses `fs.rmdir({ recursive: true })`, deprecated since Node 14.
- `socket.wgetProcess` and `socket.archiverProcess` are read in the disconnect handler but never assigned anywhere in the codebase, so that cleanup never runs and wget keeps going after the user closes the tab.
- Progress is sent with `io.emit`, so every connected client receives every other client's events, including their filename.
- Pressing Enter in the URL field submits the form to `/search`, which does not exist, and returns a 404. That is #60.

## What this changes

- Decide what to archive by reading the job directory rather than parsing wget's output, and report a real error when nothing was downloaded
- Give each request its own directory under `downloads/`, so concurrent or repeated downloads of the same site cannot collide, and clean it up afterwards
- Fence that cleanup to the downloads directory so it cannot walk up into the app
- Return archive and stream errors through a callback instead of throwing from event handlers
- Emit progress to the requesting socket instead of broadcasting to everyone
- Return a handle for the running job so the disconnect cleanup has something to cancel
- Add a size quota and a wall-clock timeout, both overridable through the environment
- Surface failures in the page instead of leaving a progress bar running
- Handle form submission so Enter starts a download

The target URL is now passed to wget through `execFile` as an argument array rather than being interpolated into an `exec()` shell string, so input from the form is no longer parsed as shell syntax. Input is also validated as a real http(s) URL before it gets that far.

## Verification

Tested on Windows with wget 1.21.4 and Node 24.

| Case | Before | After |
| --- | --- | --- |
| `http://example.com` | 22-byte empty zip, "Completed" | 629-byte zip with real content |
| `http://bit.ly` (wget writes nothing) | empty zip, "Completed" | error reported to the user |
| wget not installed | empty zip, "Completed" | error naming the install command |
| `public/sites` missing | server process died | directory created, download succeeds |
| Second user connected | received the other user's events | no cross-talk |
| Disconnect mid-download | wget kept running | wget stopped, temp directory cleaned |

I also added a Requirements section to the README noting that wget has to be on the `PATH`, since nothing downloads without it and that was not stated anywhere.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Download requests now provide clearer progress, completion, and error messages.
  * Active downloads can be cancelled automatically when the connection ends.
  * Download limits and timeouts can be configured through environment settings.
* **Bug Fixes**
  * Prevented duplicate download requests while a download is in progress.
  * Improved handling of invalid URLs, failed downloads, empty results, and archive errors.
  * Download forms no longer navigate away from the page during submission.
* **Documentation**
  * Added setup instructions for Node.js and `wget` on major operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
